### PR TITLE
add subtypes for axis styling

### DIFF
--- a/react-vis.d.ts
+++ b/react-vis.d.ts
@@ -524,7 +524,12 @@ declare module 'react-vis' {
     top?: number;
     left?: number;
     title?: string;
-    style?: CSSProperties;
+    style?: CSSProperties & {
+      line?: CSSProperties;
+      text?: CSSProperties;
+      ticks?: CSSProperties;
+      title?: CSSProperties;
+    };
     className?: string;
     hideTicks?: boolean;
     hideLine?: boolean;
@@ -555,7 +560,12 @@ declare module 'react-vis' {
     top?: number;
     left?: number;
     title?: string;
-    style?: CSSProperties;
+    style?: CSSProperties & {
+      line?: CSSProperties;
+      text?: CSSProperties;
+      ticks?: CSSProperties;
+      title?: CSSProperties;
+    };
     className?: string;
     hideTicks?: boolean;
     hideLine?: boolean;


### PR DESCRIPTION
Hey 👋 

Thanks for writing this, it's been really helpful!

react-vis allows for everything related to an axis to be styled via passing an object of the `React.CSSProperties` type - that already works with these typings.

They also allow you to specify style on the line, text, ticks, and title individually. This PR allows for that in the types.

For reference:
[docs/axes.md#style-optional](https://github.com/uber/react-vis/blob/master/docs/axes.md#style-optional)
[docs/style.md](https://github.com/uber/react-vis/blob/master/docs/style.md)