### PR TITLE
Add string type to X on LineSeriesPoint

### DIFF
--- a/react-vis.d.ts
+++ b/react-vis.d.ts
@@ -48,7 +48,7 @@ declare module 'react-vis' {
 
 
   export interface LineSeriesPoint extends AbstractSeriesPoint {
-    x: number;
+    x: string | number;
     y: number;
     color?: string | number;
   }


### PR DESCRIPTION
LineSeriesPoint should include the string type on the x-axis as this is permitted for all other types of graph